### PR TITLE
Add support for "version" command line parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,21 @@ INFOMARK = $(shell printf "\033[34;1m=>\033[0m")
 GOARCH            := $(shell go env GOARCH)
 GOOS              := $(shell go env GOOS)
 BUILDTYPE_DIR     := release
+BUILD_NUM         := 2025
 
 # Build output variables
 CLI_BINARY        := copa-lineaje-scanner
 OUT_DIR           := ./dist
 BINS_OUT_DIR      := $(OUT_DIR)/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)
+CLI_VERSION       := $(shell git describe --abbrev=0 --tags | sed -e 's/^v//g')
+CLI_BUILD_NUM     := ${BUILD_NUM}
+
+DEBUG ?= 1
+ifeq ($(DEBUG), 1)
+    STRIP_DEBUG_FLAGS =
+else
+    STRIP_DEBUG_FLAGS = -s -w
+endif
 
 ################################################################################
 # Target: build (default action)                                               #
@@ -21,7 +31,7 @@ BINS_OUT_DIR      := $(OUT_DIR)/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)
 .PHONY: build
 build:
 	$(info $(INFOMARK) Building $(CLI_BINARY) ...)
-	go build -o $(BINS_OUT_DIR)/$(CLI_BINARY)
+	go build -ldflags="$(STRIP_DEBUG_FLAGS) -X 'github.com/lineaje-labs/copa-lineaje-scanner/internal/buildinfo.Version=$(CLI_VERSION)' -X 'github.com/lineaje-labs/copa-lineaje-scanner/internal/buildinfo.BuildNum=$(CLI_BUILD_NUM)'" -o $(BINS_OUT_DIR)/$(CLI_BINARY)
 
 ################################################################################
 # Target: test - unit testing                                                  #

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/project-copacetic/scanner-plugin-template
+module github.com/lineaje-labs/copa-lineaje-scanner
 
 go 1.21
 

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,16 @@
+package buildinfo
+
+var BuildNum = "2025"
+
+var Copyright = "Copyright (C) 2022-2025 Lineaje Inc - All rights reserved."
+var Name = "copa-lineaje-scanner"
+var Version = "1.0.0"
+
+func GetFullVersion() string {
+	fullVersion := Version
+	// Update the Version with Build number if available
+	if BuildNum != "" {
+		fullVersion += "-" + BuildNum
+	}
+	return fullVersion
+}

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/lineaje-labs/copa-lineaje-scanner/internal/buildinfo"
+)
+
+func GetVersion() string {
+	Copyright := buildinfo.Copyright
+	Name := buildinfo.Name
+	Version := buildinfo.Version
+	BuildNum := buildinfo.BuildNum
+	return fmt.Sprintf("%s version %s-%s\n%s\n", Name, Version, BuildNum, Copyright)
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/lineaje-labs/copa-lineaje-scanner/internal/cmd"
 	"github.com/package-url/packageurl-go"
 	"github.com/project-copacetic/copacetic/pkg/types/v1alpha1"
 )
@@ -171,6 +172,10 @@ func main() {
 	if len(os.Args) != 2 {
 		fmt.Printf("Usage: %s <image report>\n", os.Args[0])
 		os.Exit(1)
+	}
+	if os.Args[1] == "version" {
+		fmt.Print(cmd.GetVersion())
+		os.Exit(0)
 	}
 
 	// Initialize the parser


### PR DESCRIPTION
Add support for "version" command line parameter which prints the Build info parameters. They are set during make by over writing internal version values by passing ldflags