### PR TITLE
Update workflow to upload all release artifacts

### DIFF
--- a/.github/workflows/manual-build-test.yml
+++ b/.github/workflows/manual-build-test.yml
@@ -30,3 +30,9 @@ jobs:
 
       - name: Test
         run: make test
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: dist/linux_amd64/release/


### PR DESCRIPTION
This change modifies the manual build and test workflow to upload all files from the 'dist/linux_amd64/release/' directory. The uploaded artifact bundle is named 'release-artifacts'.