### PR TITLE
Add optional version input to manual build workflow

### DIFF
--- a/.github/workflows/manual-build-test.yml
+++ b/.github/workflows/manual-build-test.yml
@@ -15,6 +15,11 @@ on:
         description: 'The name of the branch or tag to checkout'
         required: true
         type: string
+      version:
+        description: 'Optional version to pass to the build (e.g., 1.0.0)'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build-and-test:
@@ -26,7 +31,12 @@ jobs:
           ref: ${{ github.event.inputs.ref_type == 'branch' && format('refs/heads/{0}', github.event.inputs.ref_name) || format('refs/tags/{0}', github.event.inputs.ref_name) }}
 
       - name: Build
-        run: make
+        run: |
+          if [[ -n "${{ github.event.inputs.version }}" ]]; then
+            make CLI_VERSION=${{ github.event.inputs.version }}
+          else
+            make
+          fi
 
       - name: Test
         run: make test


### PR DESCRIPTION
This commit updates the manual build and test workflow (`.github/workflows/manual-build-test.yml`) to accept an optional `version` input.

If a version is provided, it is passed to the `make` command as `CLI_VERSION` (e.g., `make CLI_VERSION=v1.0.0`). If no version is provided, the build step runs `make` as before.

This allows for more flexible manual builds where a specific version can be embedded into the compiled artifacts.