### PR TITLE
Convert PURL from Lineaje Report to copacetic format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,12 @@
 module github.com/lineaje-labs/copa-lineaje-scanner
 
-go 1.23.5
+go 1.24.2
 
-require github.com/project-copacetic/copacetic v0.10.0
+toolchain go1.24.4
 
-require github.com/package-url/packageurl-go v0.1.3 // indirect
+require github.com/lineaje-labs/copacetic v0.10.1-0.20250630202513-060fbcf3081a
+
+require (
+	github.com/package-url/packageurl-go v0.1.3
+	github.com/project-copacetic/copacetic v0.10.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/lineaje-labs/copacetic v0.10.1-0.20250630202513-060fbcf3081a h1:slM/Zo0/U2B8SQKNOh260MS1LU4esGQHUrB/uhYPp/w=
+github.com/lineaje-labs/copacetic v0.10.1-0.20250630202513-060fbcf3081a/go.mod h1:qF0I6NvTDCpojC3JOeuAP2s+2haRw9GejHd7HTWiPDQ=
 github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
 github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/project-copacetic/copacetic v0.10.0 h1:XMzv+i8E0aToc/k1oCBg3zc6rAbzt54F5rlM+Jaskg8=

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -7,9 +7,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/lineaje-labs/copa-lineaje-scanner/internal/buildinfo"
 	"github.com/lineaje-labs/copa-lineaje-scanner/internal/fixplan"
+	"github.com/lineaje-labs/copacetic/pkg/types/v1alpha1"
 	"github.com/package-url/packageurl-go"
-	"github.com/project-copacetic/copacetic/pkg/types/v1alpha1"
 )
 
 type LineajeParser struct{}
@@ -51,6 +52,7 @@ func (k *LineajeParser) Parse(fileName string) (*v1alpha1.UpdateManifest, error)
 				Arch: "",
 			},
 		},
+		PluginVersion: fmt.Sprintf("%s version %s-%s", buildinfo.Name, buildinfo.Version, buildinfo.BuildNum),
 	}
 
 	decoder := json.NewDecoder(file)
@@ -145,7 +147,9 @@ func streamAndConvertFixes(dec *json.Decoder, updates *v1alpha1.UpdateManifest) 
 						updates.Updates = append(updates.Updates, v1alpha1.UpdatePackage{
 							Name:             targetInstance.Name,
 							InstalledVersion: installedInstance.Version,
+							InstalledPURL:    fix.CurrentComponentPurl,
 							FixedVersion:     targetInstance.Version,
+							FixedPURL:        fix.TargetComponentPurl,
 							VulnerabilityID:  fix.VulnerabilityId,
 						})
 					}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/project-copacetic/copacetic/pkg/types/v1alpha1"
+	"github.com/lineaje-labs/copacetic/pkg/types/v1alpha1"
 )
 
 // Test newLineajeParser returns a non-nil parser pointer
@@ -56,42 +56,56 @@ func TestLineajeParser_Parse(t *testing.T) {
 						Name:             "ssl_client",
 						InstalledVersion: "1.36.0-r9",
 						FixedVersion:     "1.36.1-r7",
+						InstalledPURL:    "pkg:apk/alpine/ssl_client@1.36.0-r9?arch=x86_64&distro=alpine-3.18.0&upstream=busybox",
+						FixedPURL:        "pkg:apk/alpine/ssl_client@1.36.1-r7",
 						VulnerabilityID:  "CVE-1234-567",
 					},
 					{
 						Name:             "musl",
 						InstalledVersion: "1.2.4-r0",
 						FixedVersion:     "1.2.4-r3",
+						InstalledPURL:    "pkg:apk/alpine/musl@1.2.4-r0?arch=x86_64&distro=alpine-3.18.0",
+						FixedPURL:        "pkg:apk/alpine/musl@1.2.4-r3",
 						VulnerabilityID:  "CVE-1234-567",
 					},
 					{
 						Name:             "libssl3",
 						InstalledVersion: "3.1.0-r4",
 						FixedVersion:     "3.1.8-r0",
+						InstalledPURL:    "pkg:apk/alpine/libssl3@3.1.0-r4?arch=x86_64&distro=alpine-3.18.0&upstream=openssl",
+						FixedPURL:        "pkg:apk/alpine/libssl3@3.1.8-r0",
 						VulnerabilityID:  "CVE-1234-567",
 					},
 					{
 						Name:             "musl-utils",
 						InstalledVersion: "1.2.4-r0",
 						FixedVersion:     "1.2.4-r3",
+						InstalledPURL:    "pkg:apk/alpine/musl-utils@1.2.4-r0?arch=x86_64&distro=alpine-3.18.0&upstream=musl",
+						FixedPURL:        "pkg:apk/alpine/musl-utils@1.2.4-r3",
 						VulnerabilityID:  "CVE-1234-567",
 					},
 					{
 						Name:             "busybox-binsh",
 						InstalledVersion: "1.36.0-r9",
 						FixedVersion:     "1.36.1-r7",
+						InstalledPURL:    "pkg:apk/alpine/busybox-binsh@1.36.0-r9?arch=x86_64&distro=alpine-3.18.0&upstream=busybox",
+						FixedPURL:        "pkg:apk/alpine/busybox-binsh@1.36.1-r7",
 						VulnerabilityID:  "CVE-1234-567",
 					},
 					{
 						Name:             "libcrypto3",
 						InstalledVersion: "3.1.0-r4",
 						FixedVersion:     "3.1.8-r0",
+						InstalledPURL:    "pkg:apk/alpine/libcrypto3@3.1.0-r4?arch=x86_64&distro=alpine-3.18.0&upstream=openssl",
+						FixedPURL:        "pkg:apk/alpine/libcrypto3@3.1.8-r0",
 						VulnerabilityID:  "CVE-1234-567",
 					},
 					{
 						Name:             "busybox",
 						InstalledVersion: "1.36.0-r9",
 						FixedVersion:     "1.36.1-r7",
+						InstalledPURL:    "pkg:apk/alpine/busybox@1.36.0-r9?arch=x86_64&distro=alpine-3.18.0",
+						FixedPURL:        "pkg:apk/alpine/busybox@1.36.1-r7",
 						VulnerabilityID:  "CVE-1234-567",
 					},
 				},
@@ -119,6 +133,9 @@ func TestLineajeParser_Parse(t *testing.T) {
 			got, err := tt.parser.Parse(tt.file)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("LineajeParser.parse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != nil { // Set the plugin version as an empty variable as it will change for every build
+				got.PluginVersion = ""
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("LineajeParser.parse() = %+v, want %+v", got, tt.want)


### PR DESCRIPTION
Convert PURL from Lineaje Report to copacetic format by using the updated types in forked copacetic