### PR TITLE
Fix: Grant write permissions for release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
   build:
     name: Build Release Assets
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       release_archive_name: ${{ steps.get_archive_name.outputs.name }}
     steps:


### PR DESCRIPTION
Added `permissions: contents: write` to the release workflow to allow the GITHUB_TOKEN to create GitHub releases.