### PR TITLE
Remove OS type and version determination from PURLs

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -96,7 +96,7 @@ func streamAndConvertFixes(dec *json.Decoder, updates *v1alpha1.UpdateManifest) 
 		"qpkg":   {},
 	}
 
-	setOSDetails := false
+	setArchDetails := false
 
 	// loop through tokens until you find "basic_plan_component_vulnerability_fixes"
 	for {
@@ -132,10 +132,8 @@ func streamAndConvertFixes(dec *json.Decoder, updates *v1alpha1.UpdateManifest) 
 					}
 
 					if _, exists := osPurlTypes[strings.ToLower(installedInstance.Type)]; exists {
-						if !setOSDetails {
-							setOSDetails = true
-							updates.Metadata.OS.Type = installedInstance.Namespace
-							updates.Metadata.OS.Version = extractDistro(installedInstance.Qualifiers)
+						if !setArchDetails {
+							setArchDetails = true
 							updates.Metadata.Config.Arch = installedInstance.Qualifiers.Map()["arch"]
 						}
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -44,8 +44,8 @@ func TestLineajeParser_Parse(t *testing.T) {
 				APIVersion: v1alpha1.APIVersion,
 				Metadata: v1alpha1.Metadata{
 					OS: v1alpha1.OS{
-						Type:    "alpine",
-						Version: "3.18.0",
+						Type:    "",
+						Version: "",
 					},
 					Config: v1alpha1.Config{
 						Arch: "x86_64",


### PR DESCRIPTION
Determination of OS type and version is not safe as PURLs may contain abbreviations for operating systems (e.g., Amazon Linux as 'amzn' instead of 'amazon').

Hence, OS and version determination logic is removed from this repo and should be handled by [Copacetic](https://github.com/lineaje-labs/copacetic/tree/lineaje-v0.10.0).